### PR TITLE
Converting to base64-js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,6 +278,9 @@ node_modules/
 # Build files
 dist/
 
+# Test coverage files 
+coverage/
+
 # Visual Studio 6 build log
 *.plg
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3682,6 +3682,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3734,11 +3739,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
-    },
-    "byte-base64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/byte-base64/-/byte-base64-1.1.0.tgz",
-      "integrity": "sha512-56cXelkJrVMdCY9V/3RfDxTh4VfMFCQ5km7B7GkIGfo4bcPL9aACyJLB0Ms3Ezu5rsHmLB2suis96z4fLM03DA=="
     },
     "caching-transform": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/microsoft/connected-workbooks#readme",
   "dependencies": {
-    "byte-base64": "^1.1.0",
+    "base64-js": "^1.5.1",
     "iconv-lite": "^0.6.2",
     "jszip": "^3.5.0"
   },

--- a/src/arrayUtils.ts
+++ b/src/arrayUtils.ts
@@ -10,7 +10,7 @@ export class ArrayReader {
         this._position = 0;
     }
 
-    public getInt32() {
+    public getInt32(): number {
         const retVal = new DataView(this._array, this._position, 4).getInt32(
             0,
             true
@@ -29,18 +29,18 @@ export class ArrayReader {
         return new Uint8Array(retVal);
     }
 
-    reset() {
+    reset(): void {
         this._position = 0;
     }
 }
 
-export function getInt32Buffer(val: number) {
+export function getInt32Buffer(val: number): Uint8Array {
     const packageSizeBuffer = new ArrayBuffer(4);
     new DataView(packageSizeBuffer).setInt32(0, val, true);
     return new Uint8Array(packageSizeBuffer);
 }
 
-export function concatArrays(...args: Uint8Array[]) {
+export function concatArrays(...args: Uint8Array[]): Uint8Array {
     let size = 0;
     args.forEach((arr) => (size += arr.byteLength));
     const retVal = new Uint8Array(size);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+export const pqCustomXmlPath = "customXml/item1.xml";
+export const connectionsXmlPath = "xl/connections.xml";
+export const queryTablesPath = "xl/queryTables/";
+export const pivotCachesPath = "xl/pivotCache/";
+export const section1mPath = "Formulas/Section1.m";

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -1,0 +1,11 @@
+export const generateMashupXMLTemplate = (base64: string): string =>
+    `<?xml version="1.0" encoding="utf-16"?><DataMashup xmlns="http://schemas.microsoft.com/DataMashup">${base64}</DataMashup>`;
+
+export const generateSection1mString = (
+    queryName: string,
+    query: string
+): string =>
+    `section Section1;
+    
+    shared ${queryName} = 
+    ${query};`;

--- a/src/workbookManager.ts
+++ b/src/workbookManager.ts
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import JSZip from "jszip";
-import iconv from "iconv-lite";
 import MashupHandler from "./mashupDocumentParser";
-import WorkbookTemplate from "./workbookTemplate";
-
-const pqCustomXmlPath = "customXml/item1.xml";
-const connectionsXmlPath = "xl/connections.xml";
-const queryTablesPath = "xl/queryTables/";
-const pivotCachesPath = "xl/pivotCache/";
+import {
+    connectionsXmlPath,
+    queryTablesPath,
+    pivotCachesPath,
+} from "./constants";
+import zipUtils, { JSZip } from "./zipUtils";
 
 export class QueryInfo {
     queryMashup: string;
@@ -28,11 +26,8 @@ export class WorkbookManager {
     ): Promise<Blob> {
         const zip =
             templateFile === undefined
-                ? await JSZip.loadAsync(
-                      WorkbookTemplate.SIMPLE_QUERY_WORKBOOK_TEMPLATE,
-                      { base64: true }
-                  )
-                : await JSZip.loadAsync(templateFile);
+                ? await zipUtils.loadAsyncDefaultTemplate()
+                : await zipUtils.loadAsync(templateFile);
 
         return await this.generateSingleQueryWorkbookFromZip(zip, query);
     }
@@ -41,12 +36,12 @@ export class WorkbookManager {
         zip: JSZip,
         query: QueryInfo
     ): Promise<Blob> {
-        const old_base64 = await this.getBase64(zip);
+        const old_base64 = await zipUtils.getBase64(zip);
         const new_base64 = await this.mashupHandler.ReplaceSingleQuery(
             old_base64,
             query.queryMashup
         );
-        await this.setBase64(zip, new_base64);
+        await zipUtils.setBase64(zip, new_base64);
 
         if (query.refreshOnOpen) {
             await this.setSingleQueryRefreshOnOpen(zip);
@@ -179,26 +174,5 @@ export class WorkbookManager {
                 "No Query Table or Pivot Table found for Query1 in given template."
             );
         }
-    }
-
-    private async setBase64(zip: JSZip, base64: string) {
-        const newXml = `<?xml version="1.0" encoding="utf-16"?><DataMashup xmlns="http://schemas.microsoft.com/DataMashup">${base64}</DataMashup>`;
-        const encoded = iconv.encode(newXml, "UCS2", { addBOM: true });
-        zip.file(pqCustomXmlPath, encoded);
-    }
-
-    private async getBase64(zip: JSZip): Promise<string> {
-        const xmlValue = await zip.file(pqCustomXmlPath)?.async("uint8array");
-        if (xmlValue === undefined) {
-            throw new Error("PQ document wasn't found in zip");
-        }
-        const xmlString = iconv.decode(xmlValue.buffer as Buffer, "UTF-16");
-        const parser: DOMParser = new DOMParser();
-        const doc: Document = parser.parseFromString(xmlString, "text/xml");
-        const result = doc.childNodes[0].textContent;
-        if (result === null) {
-            throw Error("Base64 wasn't found in zip");
-        }
-        return result;
     }
 }

--- a/src/zipUtils.ts
+++ b/src/zipUtils.ts
@@ -1,0 +1,73 @@
+import JSZipModule from "jszip";
+import WorkbookTemplate from "./workbookTemplate";
+import iconv from "iconv-lite";
+import { pqCustomXmlPath, section1mPath } from "./constants";
+import {
+    generateMashupXMLTemplate,
+    generateSection1mString,
+} from "./generators";
+
+export type JSZip = JSZipModule;
+
+const loadAsync = JSZipModule.loadAsync;
+
+const loadAsyncDefaultTemplate = async (): Promise<JSZip> =>
+    await JSZipModule.loadAsync(
+        WorkbookTemplate.SIMPLE_QUERY_WORKBOOK_TEMPLATE,
+        {
+            base64: true,
+        }
+    );
+
+const loadAsyncTemplate = async (template: string): Promise<JSZip> =>
+    await JSZipModule.loadAsync(template, {
+        base64: true,
+    });
+
+const chackAndgetSection1m = async (zip: JSZip): Promise<string> => {
+    const section1m = zip.file("Formulas/Section1.m")?.async("text");
+    if (!section1m) {
+        throw new Error("Formula section wasn't found in template");
+    }
+
+    return section1m;
+};
+
+const getBase64 = async (zip: JSZip): Promise<string> => {
+    const xmlValue = await zip.file(pqCustomXmlPath)?.async("uint8array");
+    if (xmlValue === undefined) {
+        throw new Error("PQ document wasn't found in zip");
+    }
+    const xmlString = iconv.decode(xmlValue.buffer as Buffer, "UTF-16");
+    const parser: DOMParser = new DOMParser();
+    const doc: Document = parser.parseFromString(xmlString, "text/xml");
+    const result = doc.childNodes[0].textContent;
+    if (result === null) {
+        throw Error("Base64 wasn't found in zip");
+    }
+    return result;
+};
+
+const setBase64 = (zip: JSZip, base64: string): void => {
+    const newXml = generateMashupXMLTemplate(base64);
+    const encoded = iconv.encode(newXml, "UCS2", { addBOM: true });
+    zip.file(pqCustomXmlPath, encoded);
+};
+
+const setSection1m = (queryName: string, query: string, zip: JSZip): void => {
+    const newSection1m = generateSection1mString(queryName, query);
+
+    zip.file(section1mPath, newSection1m, {
+        compression: "",
+    });
+};
+
+export default {
+    loadAsyncDefaultTemplate,
+    chackAndgetSection1m,
+    loadAsyncTemplate,
+    setSection1m,
+    loadAsync,
+    getBase64,
+    setBase64,
+};

--- a/tests/arrayUtils.test.ts
+++ b/tests/arrayUtils.test.ts
@@ -1,8 +1,8 @@
 import { getInt32Buffer, concatArrays, ArrayReader } from "../src/arrayUtils";
-import * as base64 from "byte-base64";
+import { toByteArray } from "base64-js";
 
 describe("ArrayReader tests", () => {
-    const buffer = base64.base64ToBytes("UHJhaXNlIFRoZSBTdW4h").buffer;
+    const buffer = toByteArray("UHJhaXNlIFRoZSBTdW4h").buffer;
     const arrReader = new ArrayReader(buffer);
 
     test("getInt32 test", () => {

--- a/tests/mashupDocumentParser.test.ts
+++ b/tests/mashupDocumentParser.test.ts
@@ -1,0 +1,32 @@
+import MashupHandler from "../src/mashupDocumentParser";
+import zipUtils from "../src/zipUtils";
+import { simpleQuery, section1mMock } from "./mocks";
+import base64 from "base64-js";
+import { ArrayReader } from "../src/arrayUtils";
+
+describe("Mashup Document Parser tests", () => {
+    test("ReplaceSingleQuery test", async () => {
+        const mashupHandler = new MashupHandler();
+
+        const defaultZipFile = await zipUtils.loadAsyncDefaultTemplate();
+        const base64str = await zipUtils.getBase64(defaultZipFile);
+
+        const replacedQueryStr = await mashupHandler.ReplaceSingleQuery(
+            base64str,
+            simpleQuery
+        );
+
+        const buffer = base64.toByteArray(replacedQueryStr).buffer;
+        const mashupArray = new ArrayReader(buffer);
+        const startArray = mashupArray.getBytes(4);
+        const packageSize = mashupArray.getInt32();
+        const packageOPC = mashupArray.getBytes(packageSize);
+
+        const zip = await zipUtils.loadAsync(packageOPC);
+        const section1m = await zipUtils.chackAndgetSection1m(zip);
+
+        expect(section1m.replace(/ /g, "")).toEqual(
+            section1mMock.replace(/ /g, "")
+        );
+    });
+});

--- a/tests/mocks/index.ts
+++ b/tests/mocks/index.ts
@@ -1,0 +1,2 @@
+export { default as simpleQuery } from "./simpleQueryMock";
+export { default as section1mMock } from "./section1mSimpleQueryMock";

--- a/tests/mocks/section1mSimpleQueryMock.ts
+++ b/tests/mocks/section1mSimpleQueryMock.ts
@@ -1,0 +1,9 @@
+export default `section Section1;
+
+        shared Query1 = 
+
+    let
+        Source = Folder.Files("C:\\Users\\user1\\Desktop\\test")
+    in
+        Source
+    ;`;

--- a/tests/mocks/simpleQueryMock.ts
+++ b/tests/mocks/simpleQueryMock.ts
@@ -1,0 +1,6 @@
+export default `
+let
+    Source = Folder.Files("C:\\Users\\user1\\Desktop\\test")
+in
+    Source
+`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -65,5 +65,5 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src/**/*", "tests"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
- Replaced `byte-base64` with `base64-js`
- Test for `Mashup Handler`
- Fixed tests building by `tsc` 
- Simple refactor