### PR TITLE
fix DocProps export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/connected-workbooks",
-  "version": "2.1.26-beta",
+  "version": "2.1.27-beta",
   "description": "Microsoft backed, Excel advanced xlsx workbook generation JavaScript library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@
 
 import * as workbookManager from "./workbookManager";
 import { DataTypes } from "./types";
-import type { QueryInfo, FileConfigs, Grid } from "./types";
+import type { QueryInfo, FileConfigs, Grid, DocProps } from "./types";
 
 export { DataTypes };
-export type { QueryInfo, FileConfigs, Grid };
+export type { QueryInfo, FileConfigs, Grid, DocProps };
 export default workbookManager;


### PR DESCRIPTION
Before:

```typescript
import workbookManager, { Grid } from "@microsoft/connected-workbooks";
import { DocProps } from "@microsoft/connected-workbooks/dist/types";
```

After:
```typescript
import workbookManager, { DocProps, Grid } from "@microsoft/connected-workbooks";

```
