### PR TITLE
T shanim/enable multiple queries

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,13 @@ export interface QueryInfo {
     queryName?: string;
 }
 
+export interface MultipleQueriesInfo {
+    loadedQueryName: string;
+    refreshOnOpen: boolean;
+    connectionOnlyQueryNames: string[];
+    mashupDocument: string;
+}
+
 export interface DocProps {
     title?: string | null;
     subject?: string | null;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -125,7 +125,16 @@ export const elementAttributes = {
     xr16uid: "xr16:uid",
     keepAlive: "keepAlive",
     refreshedVersion: "refreshedVersion",
-    background: "background"
+    background: "background",
+    isPrivate: "IsPrivate",
+    fillEnabled: "FillEnabled",
+    fillObjectType: "FillObjectType",
+    fillToDataModelEnabled: "FillToDataModelEnabled",
+    filLastUpdated: "FillLastUpdated",
+    filledCompleteResultToWorksheet: "FilledCompleteResultToWorksheet",
+    addedToDataModel: "AddedToDataModel",
+    fillErrorCode: "FillErrorCode",
+    fillStatus: "FillStatus",
 };
 
 export const dataTypeKind = {
@@ -140,6 +149,9 @@ export const elementAttributesValues = {
     connection: (queryName: string) => `Provider=Microsoft.Mashup.OleDb.1;Data Source=$Workbook$;Location="${queryName}";`,
     connectionCommand: (queryName: string) => `SELECT * FROM [${queryName}]`,
     tableResultType: () => "sTable",
+    connectionOnlyResultType: () => "sConnectionOnly",
+    fillStatusComplete: () => "sComplete",
+    fillErrorCodeUnknown: () => "sUnknown",
     randomizedUid: () => "{" + v4().toUpperCase() + "}",
 };
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { v4 } from "uuid";
+
 export const connectionsXmlPath = "xl/connections.xml";
 export const sharedStringsXmlPath = "xl/sharedStrings.xml";
 export const sheetsXmlPath = "xl/worksheets/sheet1.xml";
@@ -85,6 +87,9 @@ export const element = {
     dimension: "dimension",
     selection: "selection",
     kindCell: "c",
+    connection: "connection",
+    connections: "connections",
+    dbpr: "dbPr",
 };
 
 export const elementAttributes = {
@@ -117,6 +122,10 @@ export const elementAttributes = {
     spans: "spans",
     x14acDyDescent: "x14ac:dyDescent",
     xr3uid: "xr3:uid",
+    xr16uid: "xr16:uid",
+    keepAlive: "keepAlive",
+    refreshedVersion: "refreshedVersion",
+    background: "background"
 };
 
 export const dataTypeKind = {
@@ -131,6 +140,7 @@ export const elementAttributesValues = {
     connection: (queryName: string) => `Provider=Microsoft.Mashup.OleDb.1;Data Source=$Workbook$;Location="${queryName}";`,
     connectionCommand: (queryName: string) => `SELECT * FROM [${queryName}]`,
     tableResultType: () => "sTable",
+    randomizedUid: () => "{" + v4().toUpperCase() + "}",
 };
 
 export const defaults = {

--- a/src/utils/xmlInnerPartsUtils.ts
+++ b/src/utils/xmlInnerPartsUtils.ts
@@ -268,6 +268,28 @@ const updatePivotTable = (tableXmlString: string, connectionId: string, refreshO
     return { isPivotTableUpdated, newPivotTable };
 };
 
+const addNewConnection = async (connectionsXmlString: string, queryName: string): Promise<string> => {
+    const parser: DOMParser = new DOMParser();
+    const serializer: XMLSerializer = new XMLSerializer();
+    const connectionsDoc: Document = parser.parseFromString(connectionsXmlString, xmlTextResultType);
+    const connections = connectionsDoc.getElementsByTagName(element.connections)[0];
+    const newConnection = connectionsDoc.createElementNS(connectionsDoc.documentElement.namespaceURI, element.connection);
+    connections.append(newConnection);
+    newConnection.setAttribute(elementAttributes.id, [...connectionsDoc.getElementsByTagName(element.connection)].length.toString());
+    newConnection.setAttribute(elementAttributes.xr16uid, elementAttributesValues.randomizedUid());
+    newConnection.setAttribute(elementAttributes.keepAlive, trueValue);
+    newConnection.setAttribute(elementAttributes.name, elementAttributesValues.connectionName(queryName));
+    newConnection.setAttribute(elementAttributes.description, elementAttributesValues.connectionDescription(queryName));
+    newConnection.setAttribute(elementAttributes.type, "5");
+    newConnection.setAttribute(elementAttributes.refreshedVersion, falseValue);
+    newConnection.setAttribute(elementAttributes.background, trueValue);
+    const newDbPr = connectionsDoc.createElementNS(connectionsDoc.documentElement.namespaceURI, element.dbpr);
+    newDbPr.setAttribute(elementAttributes.connection, elementAttributesValues.connection(queryName));
+    newDbPr.setAttribute(elementAttributes.command, elementAttributesValues.connectionCommand(queryName));
+    newConnection.appendChild(newDbPr);
+    return serializer.serializeToString(connectionsDoc);
+    };
+
 export default {
     updateDocProps,
     clearLabelInfo,
@@ -277,4 +299,5 @@ export default {
     updatePivotTablesandQueryTables,
     updateQueryTable,
     updatePivotTable,
+    addNewConnection,
 };

--- a/src/utils/xmlPartsUtils.ts
+++ b/src/utils/xmlPartsUtils.ts
@@ -12,7 +12,7 @@ import {
     sheetsXmlPath,
     sheetsNotFoundErr,
 } from "./constants";
-import { replaceSingleQuery } from "./mashupDocumentParser";
+import { addConnectionOnlyQuery, replaceSingleQuery } from "./mashupDocumentParser";
 import { FileConfigs, TableData } from "../types";
 import pqUtils from "./pqUtils";
 import xmlInnerPartsUtils from "./xmlInnerPartsUtils";
@@ -27,7 +27,7 @@ const updateWorkbookDataAndConfigurations = async (zip: JSZip, fileConfigs?: Fil
     await tableUtils.updateTableInitialDataIfNeeded(zip, tableData, updateQueryTable);
 };
 
-const updateWorkbookPowerQueryDocument = async (zip: JSZip, queryName: string, queryMashupDoc: string): Promise<void> => {
+const updateWorkbookPowerQueryDocument = async (zip: JSZip, queryName: string, queryMashupDoc: string, connectionOnlyQueryNames?: string[]): Promise<void> => {
     const old_base64: string | undefined = await pqUtils.getBase64(zip);
 
     if (!old_base64) {
@@ -35,7 +35,11 @@ const updateWorkbookPowerQueryDocument = async (zip: JSZip, queryName: string, q
     }
 
     const new_base64: string = await replaceSingleQuery(old_base64, queryName, queryMashupDoc);
-    await pqUtils.setBase64(zip, new_base64);
+    let updated_base64: string = new_base64;
+    if (connectionOnlyQueryNames) {
+        updated_base64 = await addConnectionOnlyQuery(new_base64, connectionOnlyQueryNames);
+    }    
+    await pqUtils.setBase64(zip, updated_base64);
 };
 
 const updateWorkbookSingleQueryAttributes = async (zip: JSZip, queryName: string, refreshOnOpen: boolean): Promise<void> => {

--- a/src/utils/xmlPartsUtils.ts
+++ b/src/utils/xmlPartsUtils.ts
@@ -70,8 +70,22 @@ const updateWorkbookSingleQueryAttributes = async (zip: JSZip, queryName: string
     await xmlInnerPartsUtils.updatePivotTablesandQueryTables(zip, queryName, refreshOnOpen, connectionId!);
 };
 
+const addConnectionOnlyQueriesToWorkbook = async (zip: JSZip, connectionOnlyQueryNames: string[]): Promise<void> => {
+    // Update connections
+    let connectionsXmlString: string | undefined = await zip.file(connectionsXmlPath)?.async(textResultType);
+    if (connectionsXmlString === undefined) {
+        throw new Error(connectionsNotFoundErr);
+    }
+
+    connectionOnlyQueryNames.forEach(async (queryName: string) => { 
+        connectionsXmlString = await xmlInnerPartsUtils.addNewConnection(connectionsXmlString!, queryName);
+    });
+    
+};
+
 export default {
     updateWorkbookDataAndConfigurations,
     updateWorkbookPowerQueryDocument,
     updateWorkbookSingleQueryAttributes,
+    addConnectionOnlyQueriesToWorkbook,
 };

--- a/src/workbookManager.ts
+++ b/src/workbookManager.ts
@@ -98,7 +98,7 @@ const generateSingleQueryWorkbookFromZip = async (zip: JSZip, query: QueryInfo, 
 };
 
 const generateMultipleQueryWorkbookFromZip = async (zip: JSZip, queries: MultipleQueriesInfo, fileConfigs?: FileConfigs, tableData?: TableData): Promise<Blob> => {
-    await xmlPartsUtils.updateWorkbookPowerQueryDocument(zip, queries.loadedQueryName, queries.mashupDocument);
+    await xmlPartsUtils.updateWorkbookPowerQueryDocument(zip, queries.loadedQueryName, queries.mashupDocument, queries.connectionOnlyQueryNames);
     await xmlPartsUtils.updateWorkbookSingleQueryAttributes(zip, queries.loadedQueryName, queries.refreshOnOpen);
     await xmlPartsUtils.updateWorkbookDataAndConfigurations(zip, fileConfigs, tableData, true /*updateQueryTable*/);    
     await xmlPartsUtils.addConnectionOnlyQueriesToWorkbook(zip, queries.connectionOnlyQueryNames);

--- a/src/workbookManager.ts
+++ b/src/workbookManager.ts
@@ -13,7 +13,7 @@ import {
     tableNotFoundErr,
     templateFileNotSupportedErr,
 } from "./utils/constants";
-import { QueryInfo, TableData, Grid, FileConfigs } from "./types";
+import { QueryInfo, TableData, Grid, FileConfigs, MultipleQueriesInfo } from "./types";
 import { generateSingleQueryMashup } from "./generators";
 
 export const generateSingleQueryWorkbook = async (query: QueryInfo, initialDataGrid?: Grid, fileConfigs?: FileConfigs): Promise<Blob> => {
@@ -38,6 +38,22 @@ export const generateSingleQueryWorkbook = async (query: QueryInfo, initialDataG
     const tableData = initialDataGrid ? gridUtils.parseToTableData(initialDataGrid) : undefined;
 
     return await generateSingleQueryWorkbookFromZip(zip, query, fileConfigs, tableData);
+};
+
+export const generateMultipleQueryWorkbook = async (queries: MultipleQueriesInfo, initialDataGrid?: Grid, fileConfigs?: FileConfigs): Promise<Blob> => {
+    const templateFile: File | undefined = fileConfigs?.templateFile;
+    if (templateFile !== undefined && initialDataGrid !== undefined) {
+        throw new Error(templateWithInitialDataErr);
+    }
+
+    pqUtils.validateQueryName(queries.loadedQueryName);
+
+    const zip: JSZip =
+        templateFile === undefined ? await JSZip.loadAsync(SIMPLE_QUERY_WORKBOOK_TEMPLATE, { base64: true }) : await JSZip.loadAsync(templateFile);
+
+    const tableData = initialDataGrid ? gridUtils.parseToTableData(initialDataGrid) : undefined;
+
+    return await generateMultipleQueryWorkbookFromZip(zip, queries, fileConfigs, tableData);
 };
 
 export const generateTableWorkbookFromHtml = async (htmlTable: HTMLTableElement, fileConfigs?: FileConfigs): Promise<Blob> => {
@@ -74,6 +90,18 @@ const generateSingleQueryWorkbookFromZip = async (zip: JSZip, query: QueryInfo, 
     await xmlPartsUtils.updateWorkbookPowerQueryDocument(zip, query.queryName, generateSingleQueryMashup(query.queryName, query.queryMashup));
     await xmlPartsUtils.updateWorkbookSingleQueryAttributes(zip, query.queryName, query.refreshOnOpen);
     await xmlPartsUtils.updateWorkbookDataAndConfigurations(zip, fileConfigs, tableData, true /*updateQueryTable*/);
+
+    return await zip.generateAsync({
+        type: blobFileType,
+        mimeType: application,
+    });
+};
+
+const generateMultipleQueryWorkbookFromZip = async (zip: JSZip, queries: MultipleQueriesInfo, fileConfigs?: FileConfigs, tableData?: TableData): Promise<Blob> => {
+    await xmlPartsUtils.updateWorkbookPowerQueryDocument(zip, queries.loadedQueryName, queries.mashupDocument);
+    await xmlPartsUtils.updateWorkbookSingleQueryAttributes(zip, queries.loadedQueryName, queries.refreshOnOpen);
+    await xmlPartsUtils.updateWorkbookDataAndConfigurations(zip, fileConfigs, tableData, true /*updateQueryTable*/);    
+    await xmlPartsUtils.addConnectionOnlyQueriesToWorkbook(zip, queries.connectionOnlyQueryNames);
 
     return await zip.generateAsync({
         type: blobFileType,


### PR DESCRIPTION
Includes - Workbook + mashup document support for connection-only queries with single loaded query. Contains new API for multiple queries.
Doesn't include - testing & mashup doc validation.