### PR TITLE
fix: Correct data type 'number' constant to 'n'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ coverage/
 
 # bundles
 *.tgz
+
+.idea

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -122,7 +122,7 @@ export const elementAttributes = {
 
 export const dataTypeKind = {
     string: "str",
-    number: "1",
+    number: "n",
     boolean: "b",
 };
 


### PR DESCRIPTION
The official xlsx spec defines that the t property of a cell should have `t='n'` if the cell type is number.

This fix also makes the exported Excel sheet work with LibreOffice correctly, since that expects 'n' as the type of number cell.

Before, sheets exported with `@microsoft/connected-workbooks` and opened in LibreOffice Calc would not display numbers in number cells at all, those cells would be blank.

For Excel sheets, this does not change anything, since Excel understands `t='n'` as the type as well. 

Actually, `t='1'` is a derivative from the spec, and it seems to be just per chance that Excel understands it.

Therefore, I changed dataTypeKind.number from `t='1'` to `t='n'`.

In the following, I used the code from https://github.com/microsoft/connected-workbooks?tab=readme-ov-file#2-export-a-table-from-raw-data to export data to a sheet and compare their view in LibreOffice vs Excel. I used Excel online, since I am working on a Linux machine.

The first image shows the result of an export using the original code, `dataTypeKind.number = "1"`, in both applications. Excel Online is on the left, LibreOffice Calc is on the right.

![corrupt-export](https://github.com/microsoft/connected-workbooks/assets/40568557/37bd498b-bfe6-47fa-890a-67ccdc195797)

The second image is the same, but showing the result of an export using modified code of this library from this PR, `dataTypeKind.number = "n"`.

![working-export](https://github.com/microsoft/connected-workbooks/assets/40568557/110b5b8b-f363-43a3-887a-52d831d545fe)

As you can see, in the second image, both applications, LibreOffice and Excel, are showing the numbers correctly.

For further reference, compare the `xlsx` specification, Part 1 “Fundamentals And Markup Language Reference”, 5th edition, December 2016, p. 2451: https://ecma-international.org/publications-and-standards/standards/ecma-376/

Please do leave feedback on this PR, since I haven't opened a PR in a public library before.

