### PR TITLE
Fix few security warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -156,7 +156,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "semver": "^6.3.0",
+        "semver": "^6.3.1",
         "source-map": "^0.5.0"
       },
       "engines": {
@@ -216,7 +216,7 @@
         "@babel/compat-data": "^7.14.5",
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -274,7 +274,7 @@
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
-        "semver": "^6.1.2"
+        "semver": "^6.3.1"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0-0"
@@ -1688,7 +1688,7 @@
         "babel-plugin-polyfill-corejs3": "^0.2.2",
         "babel-plugin-polyfill-regenerator": "^0.2.2",
         "core-js-compat": "^3.15.0",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2461,7 +2461,7 @@
         "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "ssri": "^8.0.1",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
@@ -2495,7 +2495,7 @@
       "dev": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
-        "semver": "^7.3.5"
+        "semver": "^7.5.2"
       }
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
@@ -2525,7 +2525,7 @@
         "npm-pick-manifest": "^6.1.1",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "which": "^2.0.2"
       }
     },
@@ -2624,7 +2624,7 @@
         "cacache": "^15.0.5",
         "json-parse-even-better-errors": "^2.3.1",
         "pacote": "^12.0.0",
-        "semver": "^7.3.2"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16"
@@ -2896,7 +2896,7 @@
       "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -3554,7 +3554,7 @@
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -3699,7 +3699,7 @@
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -4385,7 +4385,7 @@
       "dependencies": {
         "@babel/compat-data": "^7.13.11",
         "@babel/helper-define-polyfill-provider": "^0.2.2",
-        "semver": "^6.1.1"
+        "semver": "^6.3.1"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -5098,7 +5098,7 @@
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.6",
-        "semver": "7.0.0"
+        "semver": "7.5.2"
       },
       "funding": {
         "type": "opencollective",
@@ -5106,12 +5106,18 @@
       }
     },
     "node_modules/core-js-compat/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/core-util-is": {
@@ -5712,7 +5718,7 @@
         "optionator": "^0.9.1",
         "progress": "^2.0.0",
         "regexpp": "^3.1.0",
-        "semver": "^7.2.1",
+        "semver": "^7.5.2",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
         "table": "^6.0.9",
@@ -6912,8 +6918,8 @@
       }
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
     },
@@ -7153,7 +7159,7 @@
         "@babel/core": "^7.7.5",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=8"
@@ -7769,7 +7775,7 @@
         "jest-util": "^27.0.6",
         "natural-compare": "^1.4.0",
         "pretty-format": "^27.0.6",
-        "semver": "^7.3.2"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -8231,7 +8237,7 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=8"
@@ -8687,7 +8693,7 @@
         "nopt": "^5.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "tar": "^6.1.2",
         "which": "^2.0.2"
       },
@@ -8830,7 +8836,7 @@
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
+        "semver": "^5.7.2",
         "validate-npm-package-license": "^3.0.1"
       }
     },
@@ -8873,7 +8879,7 @@
       "integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.1.1"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=10"
@@ -8907,7 +8913,7 @@
       "dev": true,
       "dependencies": {
         "hosted-git-info": "^4.0.1",
-        "semver": "^7.3.4",
+        "semver": "^7.5.2",
         "validate-npm-package-name": "^3.0.0"
       },
       "engines": {
@@ -8956,7 +8962,7 @@
         "npm-install-checks": "^4.0.0",
         "npm-normalize-package-bin": "^1.0.1",
         "npm-package-arg": "^8.1.2",
-        "semver": "^7.3.4"
+        "semver": "^7.5.2"
       }
     },
     "node_modules/npm-pick-manifest/node_modules/semver": {
@@ -8998,7 +9004,7 @@
       "dev": true,
       "dependencies": {
         "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
@@ -10354,7 +10360,7 @@
       "dependencies": {
         "hosted-git-info": "^6.0.0",
         "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
@@ -10986,7 +10992,7 @@
       "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11339,7 +11345,7 @@
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
       "dev": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip": "^2.0.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -11968,7 +11974,7 @@
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
         "micromatch": "^4.0.0",
-        "semver": "^7.3.4"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12069,7 +12075,7 @@
       "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -13142,7 +13148,7 @@
         "preferred-pm": "^3.0.3",
         "pretty-bytes": "^5.3.0",
         "readable-stream": "^4.3.0",
-        "semver": "^7.1.3",
+        "semver": "^7.5.2",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0",
         "text-table": "^0.2.0",
@@ -13212,7 +13218,7 @@
         "pacote": "^15.2.0",
         "read-pkg-up": "^7.0.1",
         "run-async": "^2.0.0",
-        "semver": "^7.2.1",
+        "semver": "^7.5.2",
         "shelljs": "^0.8.5",
         "sort-keys": "^4.2.0",
         "text-table": "^0.2.0"
@@ -13235,7 +13241,7 @@
       "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -13253,7 +13259,7 @@
         "proc-log": "^3.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "which": "^3.0.0"
       },
       "engines": {
@@ -13359,7 +13365,7 @@
       "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.0.0"
+        "semver": "^7.5.2"
       }
     },
     "node_modules/yeoman-generator/node_modules/cacache": {
@@ -13621,7 +13627,7 @@
         "nopt": "^6.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "tar": "^6.1.2",
         "which": "^2.0.2"
       },
@@ -13680,7 +13686,7 @@
       "integrity": "sha512-dH3GmQL4vsPtld59cOn8uY0iOqRmqKvV+DLGwNXV/Q7MDgD2QfOADWd/mFXcIE5LVhYYGjA3baz6W9JneqnuCw==",
       "dev": true,
       "dependencies": {
-        "semver": "^7.1.1"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -13703,7 +13709,7 @@
       "dependencies": {
         "hosted-git-info": "^6.0.0",
         "proc-log": "^3.0.0",
-        "semver": "^7.3.5",
+        "semver": "^7.5.2",
         "validate-npm-package-name": "^5.0.0"
       },
       "engines": {
@@ -13731,7 +13737,7 @@
         "npm-install-checks": "^6.0.0",
         "npm-normalize-package-bin": "^3.0.0",
         "npm-package-arg": "^10.0.0",
-        "semver": "^7.3.5"
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/connected-workbooks",
-  "version": "3.1.0-beta.1",
+  "version": "3.1.1-beta.1",
   "description": "Microsoft backed, Excel advanced xlsx workbook generation JavaScript library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
1. Bump ip from 2.0.0 to 2.0.1
2. semver vulnerable to Regular Expression Denial of Service - Versions of the package semver before 7.5.2 on the 7.x branch, before 6.3.1 on the 6.x branch, and all other versions before 5.7.2 are vulnerable to Regular Expression Denial of Service (ReDoS) via the function new Range, when untrusted user data is provided as a range.

- After build locally all warnings are gone.
- validated the change using the sandboxes check the all APIs.