### PR TITLE
Custom xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/connected-workbooks",
-  "version": "3.3.1-beta",
+  "version": "3.3.7-beta",
   "description": "Microsoft backed, Excel advanced xlsx workbook generation JavaScript library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/connected-workbooks",
-  "version": "3.3.7-beta",
+  "version": "3.3.3-beta",
   "description": "Microsoft backed, Excel advanced xlsx workbook generation JavaScript library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -17,7 +17,8 @@ export const docMetadataXmlPath = "docMetadata";
 export const docPropsRootElement = "cp:coreProperties";
 export const workbookRelsXmlPath = "xl/_rels/workbook.xml.rels";
 export const contentTypesXmlPath = "[Content_Types].xml";
-export const customXmlXmlPath = "customXML";
+export const customXmlXmlPath = "customXml";
+export const customXmlFolderName = "customXml";
 
 export const sharedStringsNotFoundErr = "SharedStrings were not found in template";
 export const connectionsNotFoundErr = "Connections were not found in template";
@@ -95,6 +96,8 @@ export const element = {
     kindCell: "c",
     sheet: "sheet",
     override: "Override",
+    relationship: "Relationship",
+    relationships: "Relationships",
 };
 
 export const elementAttributes = {
@@ -109,6 +112,7 @@ export const elementAttributes = {
     name: "name",
     description: "description",
     id: "id",
+    Id: "Id",
     relationId: "r:id",
     type: "Type",
     value: "Value",
@@ -132,6 +136,7 @@ export const elementAttributes = {
     target: "Target",
     partName: "PartName",
     contentType: "ContentType",
+    relationshipIdPrefix: "rId",
 };
 
 export const dataTypeKind = {
@@ -179,24 +184,20 @@ export const OFU = {
 };
 
 export const customXML = {
-    customXMLItem: "itemX.xml",
-    customXMLItemProps: "itemPropsX.xml",
     customXMLItemContent: `<ConnectedWorkbook xmlns="http://schemas.microsoft.com/ConnectedWorkbook" version="1.0.0"/>`,
-    customXMLItemPropsId: "{0B384C3C-E1D4-401B-8CF4-6285949D7671}",
     customXMLItemPropsContent: `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <ds:datastoreItem ds:itemID="{0B384C3C-E1D4-401B-8CF4-6285949D7671}" xmlns:ds="http://schemas.openxmlformats.org/officeDocument/2006/customXml"><ds:schemaRefs><ds:schemaRef ds:uri="http://schemas.microsoft.com/ConnectedWorkbook"/></ds:schemaRefs></ds:datastoreItem>`,
-    customXMLRelationships: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXmlProps" Target="XXX"/></Relationships>`,
-    folderName: "customXml",
     itemPrefix: "item",
     fileExtension: ".xml",
     itemNumberPattern: /item(\d+)\.xml$/,
     itemFilePattern: /item\d+\.xml/,
     itemPropsPartNameTemplate: (itemIndex: string) => `/customXml/itemProps${itemIndex}.xml`,
     contentType: "application/vnd.openxmlformats-officedocument.customXmlProperties+xml",
+    itemPathTemplate: (itemNumber: number | string) => `customXml/item${itemNumber}.xml`,
+    itemPropsPathTemplate: (itemNumber: number | string) => `customXml/itemProps${itemNumber}.xml`,
+    itemRelsPathTemplate: (itemNumber: number | string) => `customXml/_rels/item${itemNumber}.xml.rels`,
+    customXMLRelationships: (itemNumber: number | string) => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXmlProps" Target="itemProps${itemNumber}.xml"/></Relationships>`,
+    relationshipType: "http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXml",
+    relativeItemPathTemplate: (itemNumber: number | string) => `../customXml/item${itemNumber}.xml`,
 }
-/*
-  zip.file("customXml/item1.xml", customXml);
-  zip.file("customXml/itemProps1.xml", itemProps);
-  zip.file("customXml/_rels/item1.xml.rels", itemRels);
-*/

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -16,6 +16,8 @@ export const relsXmlPath = "_rels/.rels";
 export const docMetadataXmlPath = "docMetadata";
 export const docPropsRootElement = "cp:coreProperties";
 export const workbookRelsXmlPath = "xl/_rels/workbook.xml.rels";
+export const contentTypesXmlPath = "[Content_Types].xml";
+export const customXmlXmlPath = "customXML";
 
 export const sharedStringsNotFoundErr = "SharedStrings were not found in template";
 export const connectionsNotFoundErr = "Connections were not found in template";
@@ -45,6 +47,7 @@ export const arrayIsntMxNErr = "Array isn't MxN";
 export const relsNotFoundErr = ".rels were not found in template";
 export const xlRelsNotFoundErr = "workbook.xml.rels were not found xl";
 export const columnIndexOutOfRangeErr = "Column index out of range";
+export const contentTypesNotFoundERR = "contentTypes was not found in file";
 
 export const blobFileType = "blob";
 export const uint8ArrayType = "uint8array";
@@ -91,6 +94,7 @@ export const element = {
     selection: "selection",
     kindCell: "c",
     sheet: "sheet",
+    override: "Override",
 };
 
 export const elementAttributes = {
@@ -126,6 +130,8 @@ export const elementAttributes = {
     xr3uid: "xr3:uid",
     space: "xml:space",
     target: "Target",
+    partName: "PartName",
+    contentType: "ContentType",
 };
 
 export const dataTypeKind = {
@@ -171,3 +177,26 @@ export const OFU = {
     WdOrigin: "wdOrigin",
     OpenInExcelOririgin: "OpenInExcel",
 };
+
+export const customXML = {
+    customXMLItem: "itemX.xml",
+    customXMLItemProps: "itemPropsX.xml",
+    customXMLItemContent: `<ConnectedWorkbook xmlns="http://schemas.microsoft.com/ConnectedWorkbook" version="1.0.0"/>`,
+    customXMLItemPropsId: "{0B384C3C-E1D4-401B-8CF4-6285949D7671}",
+    customXMLItemPropsContent: `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<ds:datastoreItem ds:itemID="{0B384C3C-E1D4-401B-8CF4-6285949D7671}" xmlns:ds="http://schemas.openxmlformats.org/officeDocument/2006/customXml"><ds:schemaRefs><ds:schemaRef ds:uri="http://schemas.microsoft.com/ConnectedWorkbook"/></ds:schemaRefs></ds:datastoreItem>`,
+    customXMLRelationships: `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXmlProps" Target="XXX"/></Relationships>`,
+    folderName: "customXml",
+    itemPrefix: "item",
+    fileExtension: ".xml",
+    itemNumberPattern: /item(\d+)\.xml$/,
+    itemFilePattern: /item\d+\.xml/,
+    itemPropsPartNameTemplate: (itemIndex: string) => `/customXml/itemProps${itemIndex}.xml`,
+    contentType: "application/vnd.openxmlformats-officedocument.customXmlProperties+xml",
+}
+/*
+  zip.file("customXml/item1.xml", customXml);
+  zip.file("customXml/itemProps1.xml", itemProps);
+  zip.file("customXml/_rels/item1.xml.rels", itemRels);
+*/

--- a/src/utils/xmlPartsUtils.ts
+++ b/src/utils/xmlPartsUtils.ts
@@ -29,11 +29,14 @@ const addCustomXMLToWorkbook = async (zip: JSZip): Promise<void> => {
     if (await xmlInnerPartsUtils.isCustomXmlExists(zip)) {
         return;
     }
-    xmlInnerPartsUtils.addToContentType(zip, customXmlItemNumber.toString());
-    zip.file("customXml/item"+customXmlItemNumber+".xml", customXML.customXMLItemContent.replace("X", customXmlItemNumber.toString()));
-    zip.file("customXml/itemProps"+customXmlItemNumber+".xml", customXML.customXMLItemPropsContent);
-    zip.file("customXml/_rels/item"+customXmlItemNumber+".xml.rels", customXML.customXMLRelationships.replace("XXX", `itemProps${customXmlItemNumber}.xml`));
 
+    await xmlInnerPartsUtils.addToContentType(zip, customXmlItemNumber.toString());
+    await xmlInnerPartsUtils.addCustomXmlToRels(zip, customXmlItemNumber.toString());  
+
+    // Adding the custom XML files
+    zip.file(customXML.itemPathTemplate(customXmlItemNumber), customXML.customXMLItemContent);
+    zip.file(customXML.itemPropsPathTemplate(customXmlItemNumber), customXML.customXMLItemPropsContent);
+    zip.file(customXML.itemRelsPathTemplate(customXmlItemNumber), customXML.customXMLRelationships(customXmlItemNumber));
 }
 
 const updateWorkbookDataAndConfigurations = async (zip: JSZip, fileConfigs?: FileConfigs, tableData?: TableData, updateQueryTable = false): Promise<void> => {

--- a/src/workbookManager.ts
+++ b/src/workbookManager.ts
@@ -48,6 +48,7 @@ export const generateTableWorkbookFromGrid = async (grid: Grid, fileConfigs?: Fi
     }
 
     await xmlPartsUtils.updateWorkbookDataAndConfigurations(zip, fileConfigs, tableData);
+    await xmlPartsUtils.addCustomXMLToWorkbook(zip);
 
     return await zip.generateAsync({
         type: blobFileType,


### PR DESCRIPTION
This pull request introduces support for adding custom XML parts to generated Excel workbooks, specifically for registering Connected Workbooks metadata. The changes include new utilities for managing custom XML items, updating content types and relationships, and integrating these steps into the workbook generation process. Additionally, several constants and error messages were added to support these features.

**Custom XML support for Connected Workbooks:**

* Added new utility functions in `xmlInnerPartsUtils.ts` to:
  - Determine the next available custom XML item number,
  - Check for the existence of a Connected Workbook custom XML item,
  - Add content type overrides for custom XML items,
  - Add relationships for custom XML items in the workbook relationships file. 
 
* Introduced a new function `addCustomXMLToWorkbook` in `xmlPartsUtils.ts` that orchestrates the creation and registration of custom XML items when generating a workbook.
* Integrated the custom XML addition step into the main workbook generation pipeline in `workbookManager.ts`.

**Constants and error handling enhancements:**

* Added new constants to `constants.ts` for custom XML paths, folder names, XML element/attribute names, error messages, and custom XML content templates. 
* Updated imports and usages to leverage new constants for improved maintainability and clarity. 

**Other minor improvements:**

* Updated the package version in `package.json` to `3.3.3-beta`.
* Improved error handling and folder path management for table file lookups.

These changes ensure that every generated workbook includes the necessary custom XML data and registrations for Connected Workbooks, improving interoperability and metadata support.