### PR TITLE
Fix closeing square bracket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/connected-workbooks",
-  "version": "3.3.2-beta",
+  "version": "3.3.3-beta",
   "description": "Microsoft backed, Excel advanced xlsx workbook generation JavaScript library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -147,7 +147,7 @@ export const elementAttributesValues = {
     connectionName: (queryName: string) => `Query - ${queryName}`,
     connectionDescription: (queryName: string) => `Connection to the '${queryName}' query in the workbook.`,
     connection: (queryName: string) => `Provider=Microsoft.Mashup.OleDb.1;Data Source=$Workbook$;Location="${queryName}";`,
-    connectionCommand: (queryName: string) => `SELECT * FROM [${queryName}]`,
+    connectionCommand: (queryName: string) => `SELECT * FROM [${queryName.replace(/]/g, ']]')}]`,
     tableResultType: () => "sTable",
 };
 

--- a/tests/xmlInnerPartsUtils.test.ts
+++ b/tests/xmlInnerPartsUtils.test.ts
@@ -24,6 +24,21 @@ describe("Workbook Manager tests", () => {
         expect(connectionXmlFileString.replace(/ /g, "")).toContain('refreshOnLoad="1"');
     });
 
+    test("Connection XML attributes query name with ]", async () => {
+        const { connectionXmlFileString } = await xmlInnerPartsUtils.updateConnections(mockConnectionString, "[[name]]]", true);
+        expect(connectionXmlFileString.replace(/ /g, "")).toContain("command=\"SELECT*FROM[[[name]]]]]]]\"");
+    });
+
+    test("Connection XML attributes query name with no ]", async () => {
+        const { connectionXmlFileString } = await xmlInnerPartsUtils.updateConnections(mockConnectionString, "name", true);
+        expect(connectionXmlFileString.replace(/ /g, "")).toContain("command=\"SELECT*FROM[name]\"");
+    });
+
+    test("Connection XML attributes query name with ] in the middle", async () => {
+        const { connectionXmlFileString } = await xmlInnerPartsUtils.updateConnections(mockConnectionString, "[na]me]", true);
+        expect(connectionXmlFileString.replace(/ /g, "")).toContain("command=\"SELECT*FROM[[na]]me]]]\"");
+    });
+
     test("SharedStrings XML contains new query name", async () => {
         const { newSharedStrings } = await xmlInnerPartsUtils.updateSharedStrings(
             '<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="1" uniqueCount="1"><si><t>Query1</t></si><si><t/></si></sst>',


### PR DESCRIPTION
This pull request focuses on improving the handling of query names containing the `]` character in connection commands, ensuring correct escaping for Excel compatibility. It also introduces targeted tests to verify this behavior and bumps the package version.

**Improvements to connection command escaping:**

* Updated the `connectionCommand` generator in `elementAttributesValues` to properly escape `]` characters in query names by replacing each `]` with `]]` (`src/utils/constants.ts`).

**Testing enhancements:**

* Added three new tests to `xmlInnerPartsUtils.test.ts` to verify that query names with various placements of `]` are correctly escaped in the generated connection XML (`tests/xmlInnerPartsUtils.test.ts`).

**Version bump:**

* Increased the package version from `3.3.2-beta` to `3.3.3-beta` in `package.json`.