### PR TITLE
Fix headers lower case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/connected-workbooks",
-  "version": "3.4.0-beta",
+  "version": "3.4.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/connected-workbooks",
-      "version": "3.4.0-beta",
+      "version": "3.4.1-beta",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "~0.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/connected-workbooks",
-  "version": "3.4.0-beta",
+  "version": "3.4.1-beta",
   "description": "Microsoft backed, Excel advanced xlsx workbook generation JavaScript library",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "build": "tsc",
     "build-webpack-prod": "webpack --mode=production --node-env=production",
     "build-webpack-dev": "webpack --mode=development --node-env=development",
+    "clean": "jest --clearCache",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\" --config .prettierrc",
+    "test:clean": "npm run clean && npm run test",
     "test:node": "tsc && jest --config jest.config.node.js",
     "test:jsdom": "tsc && jest --config jest.config.jsdom.js",
     "test": "npm run test:jsdom && npm run test:node"

--- a/src/utils/gridUtils.ts
+++ b/src/utils/gridUtils.ts
@@ -97,7 +97,7 @@ const validateUniqueAndValidDataArray = (arr: string[]): boolean => {
         return false; // Array contains empty elements
     }
 
-    const uniqueSet = new Set(arr);
+    const uniqueSet = new Set(arr.map(item => item.toLowerCase()));
     return uniqueSet.size === arr.length;
 };
 
@@ -112,10 +112,10 @@ const getAdjustedColumnNames = (columnNames: string[] | undefined): string[] => 
     return columnNames.map((name) => {
         let uniqueName = name;
         i = 1;
-        while (uniqueNames.has(uniqueName)) {
+        while (uniqueNames.has(uniqueName.toLowerCase())) {
             uniqueName = `${name} (${i++})`;
         }
-        uniqueNames.add(uniqueName);
+        uniqueNames.add(uniqueName.toLowerCase());
         return uniqueName;
     });
 };


### PR DESCRIPTION
This pull request introduces improvements to the handling of column name uniqueness in a case-insensitive manner and adds new npm scripts for cleaning Jest caches. The changes help ensure that column names are validated and adjusted without case sensitivity issues, and streamline the testing workflow.

**Case-insensitive column name handling:**

* Updated `validateUniqueAndValidDataArray` in `src/utils/gridUtils.ts` to check for uniqueness in a case-insensitive way by converting all items to lowercase before creating the set.
* Modified `getAdjustedColumnNames` in `src/utils/gridUtils.ts` so that column names are adjusted for uniqueness in a case-insensitive manner, ensuring names like "Column" and "column" are not treated as unique.

**NPM scripts and versioning:**

* Added `clean` (clears Jest cache) and `test:clean` (runs clean before tests) scripts to `package.json` to improve test reliability, and updated the package version to `3.4.1-beta`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17-R19)